### PR TITLE
Add Frys-IX to the Terabit Club

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ The selected members of the "1 TeraBit Club" are (as of 2025-11-19):
 * Espanix: https://www.espanix.net/stats/
 * FL-IX: https://www.communityix.org/fl-ix-networks-traffic/
 * France-IX Paris: https://www.franceix.net/en/infrastructure/statistics/
+* FrysIX: https://ixpmanager.frys-ix.net/statistics/ixp
 * giganet.ua: https://giganet.ua/en/service/global-peering
 * HKIX: https://www.hkix.net/hkix/stat/aggt/hkix-aggregate.html
 * IIX Jakarta: https://nms.iix.net.id/
@@ -80,8 +81,6 @@ The selected members of the "1 TeraBit Club" are (as of 2025-11-19):
 * True-IX: https://trueix.trueintergateway.com/statistics/ixp
 * UAE-IX: https://www.uae-ix.net/en/location/traffic-statistics
 * VIX: https://www.vix.at/vix_statistics.html
-* FrysIX: https://ixpmanager.frys-ix.net/statistics/ixp
-
 Please create a Pull Request if you find a missing member of the "1 TeraBit Club"!
 
 The picture is taken from NAPAfrica. Thanks for creating it! :-)


### PR DESCRIPTION
<img width="769" height="295" alt="FrysIX at 1.01Tbps" src="https://github.com/user-attachments/assets/3cd2a7f6-09a7-49e8-b7df-1600e5b05dc5" />

We have reached 1Tbps before (as Microsoft updates occur) but during that period we had an SNMP issue with our Nokia equipment. That has since been fixed, and the next upgrade round allowed us a clean view of being north of 1.01Tbps.