### PR TITLE
SIX.SK peak traffic exceeded 1Tbit/s on 11th Feb 2026, 1.2Tbit/s on 18th Feb 2026, and on 12th May 2026 it also surpassed 1Tbit/s.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 This is a list of IXPs that are members of the fancy "1 TeraBit Club". An IXP can only be a member of the "1 TeraBit Club" if a publicly available traffic graph shows a peak traffic of more than 1 Tbps!
 
-The "1 TeraBit Club" currently consists of 81 members.
+The "1 TeraBit Club" currently consists of 82 members.
 
-The selected members of the "1 TeraBit Club" are (as of 03/02/2026):
+The selected members of the "1 TeraBit Club" are (as of 12/05/2026):
 * AMS-IX Amsterdam: https://www.ams-ix.net/ams/documentation/total-stats
 * BBIX Tokyo: https://www.bbix.net/en/service/ix/traffic-graph/
 * BBIX Osaka: https://www.bbix.net/en/service/ix/traffic-graph/
@@ -89,6 +89,7 @@ The selected members of the "1 TeraBit Club" are (as of 03/02/2026):
 * UAE-IX: https://www.uae-ix.net/en/location/traffic-statistics
 * VIX: https://www.vix.at/vix_statistics.html
 * 1-IX.EU: https://1-ix.eu/
+* SIX.SK: https://www.six.sk/stats/
 
 Please create a Pull Request if you find a missing member of the "1 TeraBit Club"!
 


### PR DESCRIPTION
Adding SIX.SK IX from Slovakia to 1Tbit club - 1.2Tbi/s on 18.02.2026 and traffic today - over 1Tbit/s on a basic Tuesday.

@tking  - hope you will approve the request. 